### PR TITLE
Fix the detection of win32

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ program
   .parse(process.argv);
 
 function exec(command, cwd) {
-  if (!~process.platform.indexOf('win')) {
+  if (~process.platform.indexOf('win')) {
     return spawn('cmd', ['/s', '/c', command], {
       stdio: ['ignore', process.stdout, process.stderr],
       cwd: cwd || process.cwd()


### PR DESCRIPTION
In my system (Windows 10), git-deep does not recognize as windows machine and try to run sh.
Inverting the condition solves the problem.

process.platform == 'win32'